### PR TITLE
Added .gitattributes to exclude files

### DIFF
--- a/.changeset/cold-cooks-write.md
+++ b/.changeset/cold-cooks-write.md
@@ -1,0 +1,5 @@
+---
+"sublime-syntax-definition-template-tag": patch
+---
+
+Added .gitattributes to exclude files

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+.changeset export-ignore
+.github export-ignore
+.npmignore export-ignore
+.prettierignore export-ignore
+CHANGELOG.md export-ignore
+CONTRIBUTING.md export-ignore
+package.json export-ignore
+pnpm-lock.yaml export-ignore
+prettier.config.mjs export-ignore
+tests export-ignore


### PR DESCRIPTION
## Background

[`package_control_channel`](https://github.com/wbond/package_control_channel)'s pull request template asked for adding `.gitattributes`.

> I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.
>
> [3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
